### PR TITLE
Stock trading bot review

### DIFF
--- a/cross_asset_confirmation.py
+++ b/cross_asset_confirmation.py
@@ -48,10 +48,13 @@ def _get_alpaca():
     """Lazy-load Alpaca API client"""
     global _alpaca_client
     if _alpaca_client is None:
+        # Respect environment-configured Alpaca endpoint.
+        # Default remains paper trading for safety.
+        base_url = os.getenv("ALPACA_BASE_URL", "https://paper-api.alpaca.markets")
         _alpaca_client = tradeapi.REST(
             os.getenv("ALPACA_KEY"),
             os.getenv("ALPACA_SECRET"),
-            base_url="https://paper-api.alpaca.markets"
+            base_url=base_url
         )
     return _alpaca_client
 


### PR DESCRIPTION
Implement three safety fixes to improve live trading readiness by respecting `ALPACA_BASE_URL`, honoring all freeze flags, and making broker-degraded cycles reduce-only.

These changes address critical safety gaps identified during a code review aimed at preparing the bot for live trading. Specifically, they prevent hardcoded paper API usage, ensure all freeze mechanisms halt trading, and restrict new entries when the broker connection is unstable, without altering current paper trading behavior.

---
<a href="https://cursor.com/background-agent?bcId=bc-20ae45db-a990-4284-aba8-bc749171ef16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-20ae45db-a990-4284-aba8-bc749171ef16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Respect `ALPACA_BASE_URL`, hard-stop on `pre_market_freeze.flag`, and skip new entries when reconciliation reports broker degraded (reduce-only).
> 
> - **Safety/Execution**:
>   - `main.py`: Introduce `degraded_mode` from reconciliation; when true, log and skip new entries (reduce-only), still run exits/monitoring; preserve per-ticker learning path otherwise.
> - **Monitoring Guards**:
>   - `monitoring_guards.check_freeze_state`: Also checks `state/pre_market_freeze.flag`, logs reason, and treats it as a freeze (hard stop).
> - **Configuration**:
>   - `cross_asset_confirmation._get_alpaca()`: Read `ALPACA_BASE_URL` from env (default paper URL) instead of hardcoding.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ca6dffb05d2ace93b84a3c254d455189e90bc3a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->